### PR TITLE
remove unnecessary fixed versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1332,8 +1332,6 @@ dependencies = [
  "anchor-lang",
  "anchor-spl",
  "clockwork-utils",
- "toml_datetime",
- "winnow",
 ]
 
 [[package]]

--- a/programs/network/Cargo.toml
+++ b/programs/network/Cargo.toml
@@ -25,5 +25,3 @@ default = []
 anchor-lang = "0.28.0"
 anchor-spl = { features = ["mint", "token"], version = "0.28.0" }
 clockwork-utils = { path = "../../utils", version = "=2.0.19" }
-winnow = "=0.4.1"
-toml_datetime = "=0.6.1"


### PR DESCRIPTION
This eliminates the issue with the fixed dependency for toml-datetime when trying to import clockwork-sdk with anchor 0.29.0

this dependencies work fine on my end with a clean `Cargo.lock`
```
[dependencies]
anchor-lang = { version = "0.29.0", features = ["init-if-needed"] }
anchor-spl = { version = "0.29.0", features = ["metadata"] }
mpl-token-auth-rules = "1.4.3"
clockwork-sdk = { path = ".../clockwork/sdk", version = "=2.0.19" }
```